### PR TITLE
Update serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,10 @@ provider:
   runtime: python3.7
   region: eu-west-2
   deploymentBucket:
-    name: spp-results-sandbox-serverless
+    name: spp-results-${self:custom.environment}-serverless
+
+custom:
+  environment: ${env:ENVIRONMENT}
 
 layers:
   funklayer:


### PR DESCRIPTION
This change is so that we dont pull variables out of secrets manager.
uses serverless-pseudo-parameters to get account id
AWS::Account id comes from the account being deployed to and populates when the deploy happens.

Environment and Environment type are passed in from environment variables in the pipeline.

Deployment bucket name now uses environment.(because sandbox bucket contains the word sandbox and integration bucket contains the word integration)

In step functions deploy, wranglers.json is now with the code.

All changes have been tested together in 'test-pipeline-without-secrets' in the new concourse.