### PR TITLE
Inconsistant Types

### DIFF
--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -271,7 +271,6 @@ def replacement_get_dataframe(sqs_queue_url, bucket_name,
 def replacement_invoke(FunctionName, Payload):  # noqa N803
     """
     Function to replace the lambda invoke, it instead saves data to be compared.
-
     Takes the same parameters as get_dataframe, but only uses file_name and data.
     :param FunctionName: Name of the lambda to be invoked. Unused
     :param Payload: The passed in parameters and data for the original invoke.
@@ -279,6 +278,8 @@ def replacement_invoke(FunctionName, Payload):  # noqa N803
     """
     runtime = json.loads(Payload)["RuntimeVariables"]
     data = runtime["data"]
+    if type(data) == list:
+        data = json.dumps(data)
 
     with open('tests/fixtures/test_wrangler_to_method_input.json', 'w',
               encoding='utf-8') as f:


### PR DESCRIPTION
Despite the fact we said we would have a standard type for passing and returning data. Enrichment/Strata worked as they passed a JSON String but Imputation passes a JSON List as such this needs to be added.

I have tested this change does not affect Enrichment or Strata.

NOTE: I believe a quick tech debt may be in order to correct this. It would be simply wrapping json.loads()/json.dumps() around the data when put into the payload and picked up again.
e.g. To match Imputation unless someone has a reason to go the other direction.

Please comment below on your opinions.