### PR TITLE
Removed json.dumps due to double encoding when putting onto a queue.

### DIFF
--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -5,7 +5,6 @@ from io import StringIO
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
-
 from es_aws_functions import exception_classes
 
 extension_types = {

--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -5,6 +5,7 @@ from io import StringIO
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
+
 from es_aws_functions import exception_classes
 
 extension_types = {
@@ -297,8 +298,6 @@ def send_bpm_status(queue_url, module_name, status, run_id, current_step_num="-"
             },
             "state": status}
     }
-
-    bpm_message = json.dumps(bpm_message)
 
     send_sqs_message(queue_url, bpm_message, output_message_id, fifo=True)
 

--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -5,6 +5,7 @@ from unittest import mock
 import boto3
 import pytest
 from botocore.response import StreamingBody
+
 from es_aws_functions import aws_functions, exception_classes
 
 

--- a/es_aws_functions/test_generic_library.py
+++ b/es_aws_functions/test_generic_library.py
@@ -5,7 +5,6 @@ from unittest import mock
 import boto3
 import pytest
 from botocore.response import StreamingBody
-
 from es_aws_functions import aws_functions, exception_classes
 
 


### PR DESCRIPTION
Adam pointed out we could avoid slashes in the queue message by removing the json.dumps to stop it being encoded twice. 