### PR TITLE
Total steps cannot be none so we are defaulting to zero for now.

### DIFF
--- a/es_aws_functions/aws_functions.py
+++ b/es_aws_functions/aws_functions.py
@@ -268,7 +268,7 @@ def save_to_s3(bucket_name, output_file_name, output_data, file_prefix="",
 
 
 def send_bpm_status(queue_url, module_name, status, run_id, current_step_num=None,
-                    total_steps=None, survey="BMI"):
+                    total_steps=0, survey="BMI"):
     """
     This function is to provide status updates to the user via the BPM layer. Currently
     it is set up to place the message on an SQS queue for BPM to pick up.


### PR DESCRIPTION
BWT have agreed that for now they can accept 0 and we can rework this later to pass total steps to the methods as they want total steps to be a number greater then zero.